### PR TITLE
Made date picker default to current date/time

### DIFF
--- a/frontend/src/modules/incident-filing/components/IncidentFormInternal.js
+++ b/frontend/src/modules/incident-filing/components/IncidentFormInternal.js
@@ -528,6 +528,7 @@ class IncidentFormInternal extends Component {
                                                     type="datetime-local"
                                                     value={values.occured_date}
                                                     InputLabelProps={{ shrink: true }}
+                                                    defaultValue={moment().format("YYYY-MM-DDTHH:mm")}
                                                     onChange={handleChange}
                                                     inputProps={{
                                                         max: values.occurrence === "OCCURRED" ? moment().format("YYYY-MM-DDTHH:mm") : null,


### PR DESCRIPTION
Fix for #388. Made the date picker in incident reports default to current date/time, so that the date does not deselected on loss of focus on the field.