### PR TITLE
Fix for 523: Added categories for severity values in search

### DIFF
--- a/frontend/src/api/incident.js
+++ b/frontend/src/api/incident.js
@@ -25,10 +25,6 @@ export const getIncidents = async (filters, page = 1) => {
     query += "&q=" + filters.textSearch;
   }
 
-  if (filters.severity) {
-    query += "&severity=" + filters.severity;
-  }
-
   if (filters.category) {
     query += "&category=" + filters.category;
   }

--- a/frontend/src/ongoing-incidents/components/SearchForm.js
+++ b/frontend/src/ongoing-incidents/components/SearchForm.js
@@ -107,7 +107,7 @@ function SearchForm(props) {
             districts={districts}
             onChange={setSelectedDistrict}
       ></Search>);
-
+ let showSeverity = props.incidentType === 'COMPLAINT';
   return (
     <Formik
       initialValues={props.incidentSearchFilter}
@@ -199,31 +199,32 @@ function SearchForm(props) {
                         <MenuItem value={"VERIFIED"}>Verified</MenuItem>
                       </Select>
                     </FormControl>
-                    <FormControl className={classes.formControl}>
+                    { showSeverity ? <FormControl className={classes.formControl}>
                       <InputLabel shrink htmlFor="severity-label-placeholder">
                         Severity
                       </InputLabel>
                       <Select
-                        input={
-                          <Input
-                            name="severity"
-                            id="severity-label-placeholder"
-                          />
-                        }
-                        displayEmpty
-                        name="severity"
-                        value={values.severity}
-                        onChange={handleChange}
-                        className={classes.selectEmpty}
+                          input={
+                            <Input
+                                name="severity"
+                                id="severity-label-placeholder"
+                            />
+                          }
+                          displayEmpty
+                          name="severity"
+                          value={values.severity}
+                          onChange={handleChange}
+                          className={classes.selectEmpty}
                       >
                         <MenuItem value="">
                           <em>None</em>
                         </MenuItem>
                         {severityValues.map((val) => (
-                          <MenuItem value={val.severityValue} key={val.severityValue}>{val.category}</MenuItem>
+                            <MenuItem value={val.severityValue} key={val.severityValue}>{val.category}</MenuItem>
                         ))}
                       </Select>
-                    </FormControl>
+                    </FormControl> : null}
+
                     <FormControl className={classes.formControl}>
                       <InputLabel shrink htmlFor="status-label-placeholder">
                         Category

--- a/frontend/src/ongoing-incidents/components/SearchForm.js
+++ b/frontend/src/ongoing-incidents/components/SearchForm.js
@@ -88,17 +88,11 @@ function SearchForm(props) {
     filterIncidents(props.filters);
   }, []);
   const { classes, categories } = props;
-  const severityValues = Array(10).fill(0).map((e, i) => {
-    let val = i + 1;
-    switch(val) {
-      case 1 <= val && val <= 3:
-        return {category: 'Low', severityValue: val}
-      case 4 <= val && val <= 7:
-        return {category: 'Medium', severityValue: val}
-      default:
-        return {category: 'High', severityValue: val}
-    }
-  });
+  const severityValues = [
+        {category: 'Low', severityValue: 'low'},
+        {category: 'Medium', severityValue: 'medium'},
+        {category: 'High', severityValue: 'high'}
+      ];
   const institutions = useSelector(state => state.shared.institutions);
   const districts = useSelector(state => state.shared.districts);
   const [selectedInstitution, setSelectedInstitution] = useState("");

--- a/frontend/src/ongoing-incidents/components/SearchForm.js
+++ b/frontend/src/ongoing-incidents/components/SearchForm.js
@@ -88,7 +88,17 @@ function SearchForm(props) {
     filterIncidents(props.filters);
   }, []);
   const { classes, categories } = props;
-  const severityValues = Array(10).fill(0).map((e, i) => i + 1);
+  const severityValues = Array(10).fill(0).map((e, i) => {
+    let val = i + 1;
+    switch(val) {
+      case 1 <= val && val <= 3:
+        return {category: 'Low', severityValue: val}
+      case 4 <= val && val <= 7:
+        return {category: 'Medium', severityValue: val}
+      default:
+        return {category: 'High', severityValue: val}
+    }
+  });
   const institutions = useSelector(state => state.shared.institutions);
   const districts = useSelector(state => state.shared.districts);
   const [selectedInstitution, setSelectedInstitution] = useState("");
@@ -196,7 +206,7 @@ function SearchForm(props) {
                       </Select>
                     </FormControl>
                     <FormControl className={classes.formControl}>
-                      <InputLabel shrink htmlFor="status-label-placeholder">
+                      <InputLabel shrink htmlFor="severity-label-placeholder">
                         Severity
                       </InputLabel>
                       <Select
@@ -216,7 +226,7 @@ function SearchForm(props) {
                           <em>None</em>
                         </MenuItem>
                         {severityValues.map((val) => (
-                          <MenuItem value={val} key={val}>{val}</MenuItem>
+                          <MenuItem value={val.severityValue} key={val.severityValue}>{val.category}</MenuItem>
                         ))}
                       </Select>
                     </FormControl>


### PR DESCRIPTION
Fix for #523.

* Added categories in `SearchForm` on frontend.
* Added category-to-value mapping in backend filter.
* Removed severity search from Inquiry advanced search, as severity is not captured in inquiries.